### PR TITLE
feat: Add Htmx context to RzController classes

### DIFF
--- a/src/Rizzy/Framework/Mvc/RzController.cs
+++ b/src/Rizzy/Framework/Mvc/RzController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
 using Rizzy.Framework.Services;
+using Rizzy.Http;
 using System.Text.Json;
 
 namespace Rizzy.Framework.Mvc;
@@ -18,6 +19,11 @@ public class RzController : ControllerBase, IRizzyService, IActionFilter, IAsync
 
     /// <inheritdoc/>
     public RzViewContext ViewContext => RizzyService.ViewContext;
+
+    /// <summary>
+    /// Gets the Htmx context for the current request.
+    /// </summary>
+    public HtmxContext Htmx => RizzyService.ViewContext.Htmx;
 
     /// <inheritdoc/>
     public string CurrentActionUrl => RizzyService.CurrentActionUrl;

--- a/src/Rizzy/Framework/Mvc/RzControllerWithViews.cs
+++ b/src/Rizzy/Framework/Mvc/RzControllerWithViews.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
 using Rizzy.Framework.Services;
+using Rizzy.Http;
 
 namespace Rizzy.Framework.Mvc;
 
@@ -17,6 +18,11 @@ public class RzControllerWithViews : Controller, IRizzyService
 
     /// <inheritdoc/>
     public RzViewContext ViewContext => RizzyService.ViewContext;
+
+    /// <summary>
+    /// Gets the Htmx context for the current request.
+    /// </summary>
+    public HtmxContext Htmx => RizzyService.ViewContext.Htmx;
 
     /// <inheritdoc/>
     public string CurrentActionUrl => RizzyService.CurrentActionUrl;

--- a/src/Rizzy/Rizzy.csproj
+++ b/src/Rizzy/Rizzy.csproj
@@ -28,7 +28,7 @@
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <Version>1.0.7</Version>
+    <Version>1.0.8</Version>
     <EnablePackageValidation>true</EnablePackageValidation>
     <GenerateCompatibilitySuppressionFile>true</GenerateCompatibilitySuppressionFile>
 	<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/src/RizzyDemo/Controllers/Home/HomeController.cs
+++ b/src/RizzyDemo/Controllers/Home/HomeController.cs
@@ -74,7 +74,7 @@ public class HomeController : RzController
     public IResult Weather()
     {
         _swapService.AddSwappableComponent<NavMenu>("sidebar", null, SwapStyle.InnerHTML);
-
+        
         return View<Weather>();
     }
 


### PR DESCRIPTION
Added a new property to the `RzController` and `RzControllerWithViews` classes that exposes the Htmx context for the current request. This allows for more granular control over HTTP requests within these controllers. Also, updated the version of Rizzy in the project file from 1.0.7 to 1.0.8 and made minor formatting changes in HomeController.cs without altering functionality.
