### PR TITLE
Update Rizzy.Tests for HTMX 4 request/response/config changes

### DIFF
--- a/test/Rizzy.Tests/Configuration/HtmxConfigHeadOutletTest.cs
+++ b/test/Rizzy.Tests/Configuration/HtmxConfigHeadOutletTest.cs
@@ -1,8 +1,8 @@
 ﻿using Bunit;
-using FluentAssertions.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using Rizzy;
 using Rizzy.Components;
 using Rizzy.FluentAssertions;
 using Rizzy.Htmx;
@@ -12,6 +12,11 @@ namespace Rizzy.Configuration;
 
 public class HtmxConfigHeadOutletTest : BunitContext
 {
+    private sealed class TestNonceProvider(string nonce) : IRizzyNonceProvider
+    {
+        public string GetNonce() => nonce;
+    }
+
     [Fact]
     public void HtmxConfig_serializer()
     {
@@ -27,41 +32,24 @@ public class HtmxConfigHeadOutletTest : BunitContext
         {
             config.AntiforgeryStrategy = AntiforgeryStrategy.None;
         });
-        Services.AddScoped<IRizzyNonceProvider, RizzyNonceProvider>();
+        Services.AddScoped<IRizzyNonceProvider>(_ => new TestNonceProvider("test-nonce"));
 
         Services.Configure<HtmxConfig>(config =>
         {
-            config.AddedClass = "added-class";
-            config.AllowEval = true;
-            config.AllowScriptTags = true;
-            config.AttributesToSettle = ["attr1", "attr2"];
             config.DefaultFocusScroll = true;
             config.DefaultSettleDelay = TimeSpan.FromHours(1);
-            config.DefaultSwapDelay = TimeSpan.FromMinutes(1);
-            config.DefaultSwapStyle = SwapStyle.beforebegin;
-            config.DisableSelector = "disable-selector";
-            config.GetCacheBusterParam = true;
-            config.GlobalViewTransitions = true;
-            config.HistoryCacheSize = 1234;
-            config.HistoryEnabled = true;
-            config.IgnoreTitle = true;
-            config.IncludeIndicatorStyles = true;
+            config.DefaultSwap = SwapStyle.beforebegin;
+            config.DefaultTimeout = TimeSpan.FromSeconds(30);
+            config.History = true;
+            config.ImplicitInheritance = true;
+            config.IncludeIndicatorCSS = true;
             config.IndicatorClass = "indicator-class";
             config.InlineScriptNonce = "inline-script-nonce";
             config.InlineStyleNonce = "inline-style-nonce";
-            config.MethodsThatUseUrlParams = ["GET", "POST", "DELETE"];
-            config.RefreshOnHistoryMiss = true;
+            config.Mode = "same-origin";
+            config.NoSwap = ["204", "4xx", "5xx"];
             config.RequestClass = "request-class";
-            config.ScrollBehavior = ScrollBehavior.smooth;
-            config.ScrollIntoViewOnBoost = true;
-            config.SelfRequestsOnly = true;
-            config.SettlingClass = "settling-class";
-            config.SwappingClass = "swapping-class";
-            config.Timeout = TimeSpan.FromSeconds(30);
-            config.UseTemplateFragments = true;
-            config.WithCredentials = true;
-            config.WsBinaryType = "ws-binary-type";
-            config.WsReconnectDelay = "full-jitter";
+            config.Transitions = true;
         });
 
         var accessor = new MockHttpContextAccessor(Services);
@@ -71,48 +59,31 @@ public class HtmxConfigHeadOutletTest : BunitContext
 
         var meta = cut.Find("meta");
         meta.GetAttribute("name").Should().Be("htmx-config");
-        meta.GetAttribute("content").Should().BeJsonSemanticallyEqualTo("""
+
+        var expectedContent = $$"""
             {
-                "addedClass": "added-class",
-                "allowEval": true,
-                "allowScriptTags": true,
-                "attributesToSettle": [
-                    "attr1",
-                    "attr2"
-                ],
                 "defaultFocusScroll": true,
-                "defaultSwapStyle": "beforebegin",
-                "defaultSwapDelay": 60000,
+                "defaultSwap": "beforebegin",
                 "defaultSettleDelay": 3600000,
-                "documentNonce": accessor.HttpContext!.GetRizzyNonceProvider().GetNonce(),
-                "disableSelector": "disable-selector",
-                "getCacheBusterParam": true,
-                "globalViewTransitions": true,
-                "historyCacheSize": 1234,
-                "historyEnabled": true,
-                "ignoreTitle": true,
-                "includeIndicatorStyles": true,
+                "defaultTimeout": 30000,
+                "documentNonce": "test-nonce",
+                "history": true,
+                "implicitInheritance": true,
+                "includeIndicatorCSS": true,
                 "indicatorClass": "indicator-class",
                 "inlineScriptNonce": "inline-script-nonce",
                 "inlineStyleNonce": "inline-style-nonce",
-                "methodsThatUseUrlParams": [
-                    "GET",
-                    "POST",
-                    "DELETE"
+                "mode": "same-origin",
+                "noSwap": [
+                    "204",
+                    "4xx",
+                    "5xx"
                 ],
-                "refreshOnHistoryMiss": true,
                 "requestClass": "request-class",
-                "scrollBehavior": "smooth",
-                "scrollIntoViewOnBoost": true,
-                "selfRequestsOnly": true,
-                "settlingClass": "settling-class",
-                "swappingClass": "swapping-class",
-                "timeout": 30000,
-                "useTemplateFragments": true,
-                "withCredentials": true,
-                "wsBinaryType": "ws-binary-type",
-                "wsReconnectDelay": "full-jitter"
+                "transitions": true
             }
-            """);
+            """;
+
+        meta.GetAttribute("content").Should().BeJsonSemanticallyEqualTo(expectedContent);
     }
 }

--- a/test/Rizzy.Tests/Http/HtmxRequestTests.cs
+++ b/test/Rizzy.Tests/Http/HtmxRequestTests.cs
@@ -84,51 +84,34 @@ public class HtmxRequestTests
     }
 
     [Fact]
-    public void TriggerName_ReturnsTriggerName_WhenTriggerNameHeaderIsPresent()
+    public void Source_ReturnsSource_WhenSourceHeaderIsPresent()
     {
         // Arrange
-        var expectedTriggerName = "submitButton";
+        var expectedSource = "button#submit";
         _context.Request.Headers[HtmxRequestHeaderNames.HtmxRequest] = "true";
-        _context.Request.Headers[HtmxRequestHeaderNames.TriggerName] = expectedTriggerName;
+        _context.Request.Headers[HtmxRequestHeaderNames.Source] = expectedSource;
         var htmxRequest = new HtmxRequest(_context);
 
         // Act
-        var triggerName = htmxRequest.TriggerName;
+        var source = htmxRequest.Source;
 
         // Assert
-        Assert.Equal(expectedTriggerName, triggerName);
+        Assert.Equal(expectedSource, source);
     }
 
     [Fact]
-    public void Trigger_ReturnsTriggerId_WhenTriggerHeaderIsPresent()
+    public void RequestType_ReturnsRequestType_WhenRequestTypeHeaderIsPresent()
     {
         // Arrange
-        var expectedTrigger = "submit-button";
+        var expectedRequestType = "partial";
         _context.Request.Headers[HtmxRequestHeaderNames.HtmxRequest] = "true";
-        _context.Request.Headers[HtmxRequestHeaderNames.Trigger] = expectedTrigger;
+        _context.Request.Headers[HtmxRequestHeaderNames.RequestType] = expectedRequestType;
         var htmxRequest = new HtmxRequest(_context);
 
         // Act
-        var trigger = htmxRequest.Trigger;
+        var requestType = htmxRequest.RequestType;
 
         // Assert
-        Assert.Equal(expectedTrigger, trigger);
-    }
-
-    [Fact]
-    public void Prompt_ReturnsPromptValue_WhenPromptHeaderIsPresent()
-    {
-        // Arrange
-        var expectedPrompt = "Are you sure?";
-        _context.Request.Headers[HtmxRequestHeaderNames.HtmxRequest] = "true";
-        _context.Request.Headers[HtmxRequestHeaderNames.Prompt] = expectedPrompt;
-        var htmxRequest = new HtmxRequest(_context);
-
-        // Act
-        var prompt = htmxRequest.Prompt;
-
-        // Assert
-        Assert.Equal(expectedPrompt, prompt);
+        Assert.Equal(expectedRequestType, requestType);
     }
 }
-

--- a/test/Rizzy.Tests/Http/HtmxResponseTests.cs
+++ b/test/Rizzy.Tests/Http/HtmxResponseTests.cs
@@ -195,21 +195,18 @@ public class HtmxResponseTests : BunitContext
         context.Response.Headers[HtmxResponseHeaderNames.Reselect].Should().Equal([".new-selection"]);
     }
 
-    [Theory]
-    [InlineData(TriggerTiming.Default, HtmxResponseHeaderNames.Trigger)]
-    [InlineData(TriggerTiming.AfterSwap, HtmxResponseHeaderNames.TriggerAfterSwap)]
-    [InlineData(TriggerTiming.AfterSettle, HtmxResponseHeaderNames.TriggerAfterSettle)]
-    public void Trigger_without_details(TriggerTiming triggerTiming, string expectedHeaderKey)
+    [Fact]
+    public void Trigger_without_details()
     {
         // Arrange
         var context = CreateHttpContext();
         var response = context.Response.Htmx();
 
         // Act
-        response.Trigger("event1", timing: triggerTiming);
+        response.Trigger("event1");
 
         // Assert
-        context.Response.Headers[expectedHeaderKey]
+        context.Response.Headers[HtmxResponseHeaderNames.Trigger]
             .Should()
             .ContainSingle()
             .Which
@@ -217,22 +214,19 @@ public class HtmxResponseTests : BunitContext
             .Be("event1");
     }
 
-    [Theory]
-    [InlineData(TriggerTiming.Default, HtmxResponseHeaderNames.Trigger)]
-    [InlineData(TriggerTiming.AfterSwap, HtmxResponseHeaderNames.TriggerAfterSwap)]
-    [InlineData(TriggerTiming.AfterSettle, HtmxResponseHeaderNames.TriggerAfterSettle)]
-    public void Multiple_trigger_events_without_details(TriggerTiming triggerTiming, string expectedHeaderKey)
+    [Fact]
+    public void Multiple_trigger_events_without_details()
     {
         // Arrange
         var context = CreateHttpContext();
         var response = context.Response.Htmx();
 
         // Act
-        response.Trigger("event1", timing: triggerTiming);
-        response.Trigger("event2", timing: triggerTiming);
+        response.Trigger("event1");
+        response.Trigger("event2");
 
         // Assert
-        context.Response.Headers[expectedHeaderKey]
+        context.Response.Headers[HtmxResponseHeaderNames.Trigger]
             .Should()
             .ContainSingle()
             .Which
@@ -240,22 +234,19 @@ public class HtmxResponseTests : BunitContext
             .Be("event1,event2");
     }
 
-    [Theory]
-    [InlineData(TriggerTiming.Default, HtmxResponseHeaderNames.Trigger)]
-    [InlineData(TriggerTiming.AfterSwap, HtmxResponseHeaderNames.TriggerAfterSwap)]
-    [InlineData(TriggerTiming.AfterSettle, HtmxResponseHeaderNames.TriggerAfterSettle)]
-    public void Same_trigger_event_twice_without_details(TriggerTiming triggerTiming, string expectedHeaderKey)
+    [Fact]
+    public void Same_trigger_event_twice_without_details()
     {
         // Arrange
         var context = CreateHttpContext();
         var response = context.Response.Htmx();
 
         // Act
-        response.Trigger("event1", timing: triggerTiming);
-        response.Trigger("event1", timing: triggerTiming);
+        response.Trigger("event1");
+        response.Trigger("event1");
 
         // Assert
-        context.Response.Headers[expectedHeaderKey]
+        context.Response.Headers[HtmxResponseHeaderNames.Trigger]
             .Should()
             .ContainSingle()
             .Which
@@ -263,11 +254,8 @@ public class HtmxResponseTests : BunitContext
             .Be("event1");
     }
 
-    [Theory]
-    [InlineData(TriggerTiming.Default, HtmxResponseHeaderNames.Trigger)]
-    [InlineData(TriggerTiming.AfterSwap, HtmxResponseHeaderNames.TriggerAfterSwap)]
-    [InlineData(TriggerTiming.AfterSettle, HtmxResponseHeaderNames.TriggerAfterSettle)]
-    public void Trigger_DefaultObject_AddsTriggerHeaderWithJsonString(TriggerTiming triggerTiming, string expectedHeaderKey)
+    [Fact]
+    public void Trigger_DefaultObject_AddsTriggerHeaderWithJsonString()
     {
         // Arrange
         var context = CreateHttpContext();
@@ -275,10 +263,10 @@ public class HtmxResponseTests : BunitContext
         var triggerObject = new { level = "info", message = "Here Is A Message" };
 
         // Act
-        response.Trigger("showMessage", triggerObject, triggerTiming);
+        response.Trigger("showMessage", triggerObject);
 
         // Assert
-        context.Response.Headers[expectedHeaderKey]
+        context.Response.Headers[HtmxResponseHeaderNames.Trigger]
             .Should()
             .ContainSingle()
             .Which
@@ -288,23 +276,20 @@ public class HtmxResponseTests : BunitContext
                 """);
     }
 
-    [Theory]
-    [InlineData(TriggerTiming.Default, HtmxResponseHeaderNames.Trigger)]
-    [InlineData(TriggerTiming.AfterSwap, HtmxResponseHeaderNames.TriggerAfterSwap)]
-    [InlineData(TriggerTiming.AfterSettle, HtmxResponseHeaderNames.TriggerAfterSettle)]
-    public void Trigger_CanUseExistingTriggerWithMultipleTriggersWithDetail_AddsCorrectTriggerHeader(TriggerTiming triggerTiming, string expectedHeaderKey)
+    [Fact]
+    public void Trigger_CanUseExistingTriggerWithMultipleTriggersWithDetail_AddsCorrectTriggerHeader()
     {
         // Arrange
         var context = CreateHttpContext();
         var response = context.Response.Htmx();
 
         // Act
-        response.Trigger("event1", triggerTiming);
-        response.Trigger("event2", new { magic = "something" }, triggerTiming);
-        response.Trigger("event3", new { moremagic = false }, triggerTiming);
+        response.Trigger("event1");
+        response.Trigger("event2", new { magic = "something" });
+        response.Trigger("event3", new { moremagic = false });
 
         // Assert
-        context.Response.Headers[expectedHeaderKey]
+        context.Response.Headers[HtmxResponseHeaderNames.Trigger]
             .Should()
             .ContainSingle()
             .Which


### PR DESCRIPTION
### Motivation

- Align the test suite with HTMX 4 behavior where request headers, response trigger semantics, and config keys were renamed or removed.
- Ensure server-side helpers and configuration output match HTMX 4 so Rizzy can be validated against the new runtime shape.

### Description

- Updated request tests to assert HTMX 4 headers by replacing `TriggerName`/`Trigger`/`Prompt` checks with `Source` (`HX-Source`) and `RequestType` (`HX-Request-Type`) in `test/Rizzy.Tests/Http/HtmxRequestTests.cs`.
- Updated response trigger tests to remove `TriggerTiming` usage and assert that all triggers are emitted via `HX-Trigger` in `test/Rizzy.Tests/Http/HtmxResponseTests.cs`.
- Reworked `HtmxConfigHeadOutletTest` to expect HTMX 4 config keys (`defaultSwap`, `defaultTimeout`, `history`, `transitions`, `includeIndicatorCSS`, `mode`, `implicitInheritance`, `noSwap`) and added a deterministic `TestNonceProvider` for stable `documentNonce` assertions in `test/Rizzy.Tests/Configuration/HtmxConfigHeadOutletTest.cs`.

### Testing

- Ran `dotnet test test/Rizzy.Tests/Rizzy.Tests.csproj` and all tests passed: `Passed 60, Failed 0`.
- The modified tests exercised request header parsing, response header trigger merging, and the serialized HTMX config meta output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a774030b38832ba9f1366ae1d9968c)